### PR TITLE
add default filler, ignore_extra_config_keys, ignore_extra_summary_keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 dist/
 mypy-results/
 .tox/
+.idea/

--- a/src/yea/schema-wandb-testlib.json
+++ b/src/yea/schema-wandb-testlib.json
@@ -26,7 +26,17 @@
                                 "multipleOf": 1.0
                             },
                             "config": {"type": "object", "description": "Config dictionary"},
-                            "summary": {"type": "object", "description": "Summary dictionary"}
+                            "summary": {"type": "object", "description": "Summary dictionary"},
+                            "ignore_extra_config_keys": {
+                                "type": "boolean",
+                                "description": "Whether to ignore keys present in the actual config that are not listed in the expected config",
+                                "default": false
+                            },
+                            "ignore_extra_summary_keys": {
+                                "type": "boolean",
+                                "description": "Whether to ignore keys present in the actual summary that are not listed in the expected summary",
+                                "default": false
+                            }
                         },
                         "additionalProperties": false
                     }

--- a/src/yea/schema.py
+++ b/src/yea/schema.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 import jsonschema  # type:ignore
-from jsonschema import Draft7Validator
+from jsonschema import Draft7Validator, validators
 
 testlib_config_jsonschema_fname = Path(__file__).parent / "schema-wandb-testlib.json"
 with open(testlib_config_jsonschema_fname, "r") as f:
@@ -25,5 +25,38 @@ def int_checker(value):
 
 
 validator = Draft7Validator(
+    schema=testlib_config_jsonschema, format_checker=format_checker
+)
+
+
+def extend_with_default(validator_class):
+    # https://python-jsonschema.readthedocs.io/en/stable/faq/#why-doesn-t-my-schema-s-default-property-set-the-default-on-my-instance
+    validate_properties = validator_class.VALIDATORS["properties"]
+
+    def set_defaults(validator, properties, instance, schema):
+
+        errored = False
+        for error in validate_properties(
+            validator,
+            properties,
+            instance,
+            schema,
+        ):
+            errored = True
+            yield error
+
+        if not errored:
+            for property, subschema in properties.items():
+                if "default" in subschema:
+                    instance.setdefault(property, subschema["default"])
+
+    return validators.extend(
+        validator_class,
+        {"properties": set_defaults},
+    )
+
+
+DefaultFiller = extend_with_default(Draft7Validator)
+default_filler = DefaultFiller(
     schema=testlib_config_jsonschema, format_checker=format_checker
 )

--- a/src/yea/testcfg.py
+++ b/src/yea/testcfg.py
@@ -6,7 +6,7 @@ import jsonschema
 
 import yaml
 
-from .schema import validator
+from .schema import validator, default_filler
 
 
 def schema_violations_from_proposed_config(config: Dict) -> List[str]:
@@ -29,6 +29,10 @@ class TestlibConfig(dict):
             if len(schema_violation_msgs) > 0:
                 err_msg = "\n".join(schema_violation_msgs)
                 raise jsonschema.ValidationError(err_msg)
+
+        # fill defaults not specified by user
+        default_filler.validate(d)
+
 
     def __str__(self) -> str:
         return repr(self)


### PR DESCRIPTION
This PR:

- Adds in two new keys to the jsonschema, `ignore_extra_config_keys` and `ignore_extra_summary_keys`. If either of these is present 
- Adds in a default filler yea config yamls (this was actually present in a previous PR and removed  due to one of my suggestions 😅 ). This allows defaults to be set in the yea test specs, so if there is no `ignore_extra_config_keys` set in a specific test it will default to `False`. 

Effect of `ignore_extra_config_keys`: 

If true:

expected: config:`{'a': 1}`
actual: config: `{'a': 1, 'b': 3}` 
pass

If false:
expected: config:`{'a': 1}`
actual: config: `{'a': 1, 'b': 3}` 
fail, 'b': 3 is not present in expected

Same logic applies to the summary dict based on this change. 
