### PR TITLE
Allow specification of tests in function docstrings

### DIFF
--- a/src/yea/cli.py
+++ b/src/yea/cli.py
@@ -3,14 +3,13 @@
 import argparse
 import sys
 
-from yea import context, runner, yeadoc
+from yea import context, runner
 
 
 def cli_list(yc):
     print("Tests:")
     yc._args.action = "list"
-    trc = yeadoc.DocTestRunner if yc._args.doc else runner.TestRunner
-    tr = trc(yc=yc)
+    tr = runner.TestRunner(yc=yc)
     tests = tr.get_tests()
     test_ids = [len(t.test_id) for t in tests]
     tlen = max(test_ids) if test_ids else 0
@@ -21,8 +20,7 @@ def cli_list(yc):
 
 def cli_run(yc):
     yc._args.action = "run"
-    trc = yeadoc.DocTestRunner if yc._args.doc else runner.TestRunner
-    tr = trc(yc=yc)
+    tr = runner.TestRunner(yc=yc)
     tr.run()
 
 
@@ -35,7 +33,7 @@ def cli():
     parser.add_argument("--debug", action="store_true", help="Print out extra debug info")
     parser.add_argument("--shard", help="Specify testing shard")
     parser.add_argument("--suite", help="Specify testing suite")
-    parser.add_argument("--doc", help="Read tests from docstrings", action="store_true")
+    parser.add_argument("--docs-only", help="Read tests from docstrings only.", action="store_true")
 
     parse_list = subparsers.add_parser("list", aliases=["l"])
     parse_list.set_defaults(func=cli_list)

--- a/src/yea/cli.py
+++ b/src/yea/cli.py
@@ -3,23 +3,26 @@
 import argparse
 import sys
 
-from yea import context, runner
+from yea import context, runner, yeadoc
 
 
 def cli_list(yc):
     print("Tests:")
     yc._args.action = "list"
-    tr = runner.TestRunner(yc=yc)
+    trc = yeadoc.DocTestRunner if yc._args.doc else runner.TestRunner
+    tr = trc(yc=yc)
     tests = tr.get_tests()
     test_ids = [len(t.test_id) for t in tests]
     tlen = max(test_ids) if test_ids else 0
     for t in tests:
         print("  {:<{}s}: {}".format(t.test_id, tlen, t.name))
+    tr.clean()
 
 
 def cli_run(yc):
     yc._args.action = "run"
-    tr = runner.TestRunner(yc=yc)
+    trc = yeadoc.DocTestRunner if yc._args.doc else runner.TestRunner
+    tr = trc(yc=yc)
     tr.run()
 
 
@@ -32,6 +35,7 @@ def cli():
     parser.add_argument("--debug", action="store_true", help="Print out extra debug info")
     parser.add_argument("--shard", help="Specify testing shard")
     parser.add_argument("--suite", help="Specify testing suite")
+    parser.add_argument("--doc", help="Read tests from docstrings", action="store_true")
 
     parse_list = subparsers.add_parser("list", aliases=["l"])
     parse_list.set_defaults(func=cli_list)

--- a/src/yea/runner.py
+++ b/src/yea/runner.py
@@ -57,7 +57,7 @@ class TestRunner:
             for root, dirs, _ in os.walk(path_dir, topdown=True):
                 # TODO: temporary hack to avoid walking into wandb dir
                 # use .gitignore instead
-                if "wandb" in dirs:
+                if "wandb" in dirs and not from_cwd:
                     dirs.remove("wandb")
                 if ".tox" in dirs:
                     dirs.remove(".tox")

--- a/src/yea/runner.py
+++ b/src/yea/runner.py
@@ -62,15 +62,15 @@ class TestRunner:
             alist.append(str(p))
         return alist
 
-    def _get_dirs(self, from_cwd=False):
+    def _get_dirs(self):
         # generate to return all test dirs and rcursively found dirs
-        for tdir in self._cfg.test_dirs if not from_cwd else ["."]:
+        for tdir in self._cfg.test_dirs:
             path_dir = pathlib.Path(self._cfg.test_root, tdir)
             yield path_dir
             for root, dirs, _ in os.walk(path_dir, topdown=True):
                 # TODO: temporary hack to avoid walking into wandb dir
                 # use .gitignore instead
-                if "wandb" in dirs and not from_cwd:
+                if "wandb" in dirs:
                     dirs.remove("wandb")
                 if ".tox" in dirs:
                     dirs.remove(".tox")

--- a/src/yea/runner.py
+++ b/src/yea/runner.py
@@ -1,15 +1,19 @@
 # -*- coding: utf-8 -*-
 """test runner."""
-
+import ast
 import logging
 import os
 import pathlib
 import re
+import shutil
 import sys
+from typing import Dict
 
 import junit_xml
 
 from yea import testspec, ytest
+
+from .yeadoc import YeadocSnippet, load_tests_from_docstring
 
 
 logger = logging.getLogger(__name__)
@@ -25,6 +29,7 @@ def alphanum_sort(key):
 
 class TestRunner:
     def __init__(self, *, yc):
+        self.prepare()
         self._yc = yc
         self._cfg = yc._cfg
         self._args = yc._args
@@ -33,8 +38,16 @@ class TestRunner:
         self._test_list = []
         self._populate()
 
+    def prepare(self):
+        # initialize
+        self._tmpdir = pathlib.Path.cwd() / ".yeadoc"
+        if self._tmpdir.exists():
+            shutil.rmtree(self._tmpdir)
+        self._tmpdir.mkdir()
+
     def clean(self):
-        pass
+        if self._tmpdir.exists():
+            shutil.rmtree(self._tmpdir)
 
     def _get_args_list(self):
         # TODO: clean up args parsing
@@ -76,47 +89,103 @@ class TestRunner:
         if self._args.action == "run" and self._args.all:
             all_tests = True
 
+        if not self._args.docs_only:
+            for path_dir in self._get_dirs():
+                # TODO: look for .yea, or look for .py with docstring
+                for tpath in path_dir.glob("*.py"):
+                    if not all_tests and str(tpath) not in args_tests:
+                        logger.debug("skip fname {}".format(tpath))
+                        continue
+                    docstr = testspec.load_docstring(tpath)
+                    spec = testspec.load_yaml_from_docstring(docstr)
+                    if not spec:
+                        logger.debug("skip nospec {}".format(tpath))
+                        continue
+
+                    if all_tests:
+                        if spec.get("tag", {}).get("skip", False):
+                            continue
+                        suite = spec.get("tag", {}).get("suite", "main")
+                        shard = spec.get("tag", {}).get("shard", "default")
+                        if self._args.suite and self._args.suite != suite:
+                            continue
+                        if self._args.shard and self._args.shard != shard:
+                            continue
+
+                    tpaths.append(tpath)
+                for tpath in path_dir.glob("*.yea"):
+                    # TODO: parse yea file looking for path info
+                    spec = testspec.load_yaml_from_file(tpath)
+
+                    # if program is specied, keep track of yea file
+                    py_fname = spec.get("command", {}).get("program")
+                    if py_fname:
+                        # hydrate to full path, take base from tpath
+                        py_fname = os.path.join(tpath.parent, py_fname)
+                        t_fname = tpath
+                    else:
+                        py_fname = str(tpath)[:-4] + ".py"
+                        t_fname = py_fname
+
+                    if not os.path.exists(py_fname):
+                        continue
+
+                    # TODO: DRY. code is same as above, refactor sometime
+                    if all_tests:
+                        if spec.get("tag", {}).get("skip", False):
+                            continue
+                        suite = spec.get("tag", {}).get("suite", "main")
+                        shard = spec.get("tag", {}).get("shard", "default")
+                        if self._args.suite and self._args.suite != suite:
+                            continue
+                        if self._args.shard and self._args.shard != shard:
+                            continue
+
+                    if not all_tests:
+                        if py_fname not in args_tests and str(tpath) not in args_tests:
+                            logger.debug("skip yea fname {}".format(tpath))
+                            continue
+
+                    # add .yea or .py file
+                    tpaths.append(pathlib.Path(t_fname))
+
+        # pick up yea tests from docstrings
+        id_test_map: Dict[str, YeadocSnippet] = {}
         for path_dir in self._get_dirs():
-            # TODO: look for .yea, or look for .py with docstring
+            # build up the list of tests that can be run by parsing docstrings
             for tpath in path_dir.glob("*.py"):
-                if not all_tests and str(tpath) not in args_tests:
-                    logger.debug("skip fname {}".format(tpath))
-                    continue
-                docstr = testspec.load_docstring(tpath)
-                spec = testspec.load_yaml_from_docstring(docstr)
-                if not spec:
-                    logger.debug("skip nospec {}".format(tpath))
-                    continue
 
-                if all_tests:
-                    if spec.get("tag", {}).get("skip", False):
-                        continue
-                    suite = spec.get("tag", {}).get("suite", "main")
-                    shard = spec.get("tag", {}).get("shard", "default")
-                    if self._args.suite and self._args.suite != suite:
-                        continue
-                    if self._args.shard and self._args.shard != shard:
-                        continue
+                # parse the test file using ast
+                with open(tpath) as f:
+                    mod = ast.parse(f.read())
 
-                tpaths.append(tpath)
+                function_definitions = [node for node in mod.body if isinstance(node, ast.FunctionDef)]
+                for func in function_definitions:
+                    docstr = ast.get_docstring(func)
+                    snippets = load_tests_from_docstring(docstr)
+                    for s in snippets:
+                        id_test_map[s.id] = s
+
+                classes = [node for node in mod.body if isinstance(node, ast.ClassDef)]
+                for class_ in classes:
+                    methods = [node for node in class_.body if isinstance(node, ast.FunctionDef)]
+                    for func in methods:
+                        docstr = ast.get_docstring(func)
+                        snippets = load_tests_from_docstring(docstr)
+                        for s in snippets:
+                            id_test_map[s.id] = s
+
+        for path_dir in self._get_dirs():
             for tpath in path_dir.glob("*.yea"):
                 # TODO: parse yea file looking for path info
                 spec = testspec.load_yaml_from_file(tpath)
+                id_not_in_map = spec.get("id", None) not in id_test_map
+                test_selected_to_run = all_tests or spec.get("id", None) in args_tests
 
-                # if program is specied, keep track of yea file
-                py_fname = spec.get("command", {}).get("program")
-                if py_fname:
-                    # hydrate to full path, take base from tpath
-                    py_fname = os.path.join(tpath.parent, py_fname)
-                    t_fname = tpath
-                else:
-                    py_fname = str(tpath)[:-4] + ".py"
-                    t_fname = py_fname
-
-                if not os.path.exists(py_fname):
+                if id_not_in_map or not test_selected_to_run:
+                    logger.debug("skip yea fname: {}".format(tpath))
                     continue
 
-                # TODO: DRY. code is same as above, refactor sometime
                 if all_tests:
                     if spec.get("tag", {}).get("skip", False):
                         continue
@@ -127,13 +196,15 @@ class TestRunner:
                     if self._args.shard and self._args.shard != shard:
                         continue
 
-                if not all_tests:
-                    if py_fname not in args_tests and str(tpath) not in args_tests:
-                        logger.debug("skip yea fname {}".format(tpath))
-                        continue
+                # write test and spec to tempfiles
+                shutil.copy(tpath, self._tmpdir)
+                t_fname = self._tmpdir / tpath.name
+                py_fname = str(t_fname)[:-4] + ".py"
+                with open(py_fname, "w") as f:
+                    f.write(id_test_map[spec["id"]].code)
 
                 # add .yea or .py file
-                tpaths.append(pathlib.Path(t_fname))
+                tpaths.append(pathlib.Path(py_fname))
 
         tlist = []
         for tname in tpaths:
@@ -201,6 +272,7 @@ class TestRunner:
             junit_xml.TestSuite.to_file(f, [ts], prettyprint=False, encoding="utf-8")
 
     def finish(self):
+        self.clean()
         self._save_results()
         exit = 0
         print("\nResults:")

--- a/src/yea/runner.py
+++ b/src/yea/runner.py
@@ -33,6 +33,9 @@ class TestRunner:
         self._test_list = []
         self._populate()
 
+    def clean(self):
+        pass
+
     def _get_args_list(self):
         # TODO: clean up args parsing
         args_tests = getattr(self._args, "tests", None)
@@ -46,9 +49,9 @@ class TestRunner:
             alist.append(str(p))
         return alist
 
-    def _get_dirs(self):
+    def _get_dirs(self, from_cwd=False):
         # generate to return all test dirs and rcursively found dirs
-        for tdir in self._cfg.test_dirs:
+        for tdir in self._cfg.test_dirs if not from_cwd else ["."]:
             path_dir = pathlib.Path(self._cfg.test_root, tdir)
             yield path_dir
             for root, dirs, _ in os.walk(path_dir, topdown=True):

--- a/src/yea/runner.py
+++ b/src/yea/runner.py
@@ -180,7 +180,7 @@ class TestRunner:
                 # TODO: parse yea file looking for path info
                 spec = testspec.load_yaml_from_file(tpath)
                 id_not_in_map = spec.get("id", None) not in id_test_map
-                test_selected_to_run = all_tests or spec.get("id", None) in args_tests
+                test_selected_to_run = all_tests or str(tpath) in args_tests
 
                 if id_not_in_map or not test_selected_to_run:
                     logger.debug("skip yea fname: {}".format(tpath))

--- a/src/yea/runner.py
+++ b/src/yea/runner.py
@@ -174,6 +174,10 @@ class TestRunner:
                         snippets = load_tests_from_docstring(docstr)
                         for s in snippets:
                             id_test_map[s.id] = s
+                    class_docstr = ast.get_docstring(class_)
+                    snippets = load_tests_from_docstring(class_docstr)
+                    for s in snippets:
+                        id_test_map[s.id] = s
 
         for path_dir in self._get_dirs():
             for tpath in path_dir.glob("*.yea"):

--- a/src/yea/yeadoc.py
+++ b/src/yea/yeadoc.py
@@ -1,0 +1,167 @@
+import ast
+import io
+import re
+import logging
+from dataclasses import dataclass
+import pathlib
+from typing import Dict, List, Optional
+from yea.runner import TestRunner, alphanum_sort
+from yea import testspec, ytest
+import tempfile
+import shutil
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class YeadocSnippet:
+    code: str
+    lineno: int
+    id: str
+    syntax: Optional[str] = None
+
+
+def extract_from_buffer(f, max_num_lines: int = 10000) -> List[YeadocSnippet]:
+    out = []
+    previous_nonempty_line = None
+    k = 1
+
+    while True:
+        line = f.readline()
+        k += 1
+        if not line:
+            # EOF
+            break
+
+        if line.strip() == "":
+            continue
+
+        if line.lstrip()[:3] == "```":
+            syntax = line.strip()[3:]
+            num_leading_spaces = len(line) - len(line.lstrip())
+            lineno = k - 1
+            # read the block
+            code_block = []
+            while True:
+                line = f.readline()
+                k += 1
+                if not line:
+                    raise RuntimeError("Hit end-of-file prematurely. Syntax error?")
+                if k > max_num_lines:
+                    raise RuntimeError(f"File too large (> {max_num_lines} lines). Set max_num_lines.")
+                # check if end of block
+                if line.lstrip()[:3] == "```":
+                    break
+                # Cut (at most) num_leading_spaces leading spaces
+                nls = min(num_leading_spaces, len(line) - len(line.lstrip()))
+                line = line[nls:]
+                code_block.append(line)
+
+            if previous_nonempty_line is None:
+                previous_nonempty_line = line
+                continue
+
+            # check for keywords
+            m = re.match(
+                r"<!--[-\s]*yeadoc-test:(.*)-->",
+                previous_nonempty_line.strip(),
+            )
+            if m is None:
+                pass  # ignore test because it is not labeled
+            else:
+                id = m.group(1).strip("- ")
+                out.append(YeadocSnippet("".join(code_block), lineno, id, syntax))
+                continue
+
+        previous_nonempty_line = line
+
+    return out
+
+
+def load_tests_from_docstring(docstring: str) -> List[YeadocSnippet]:
+    return extract_from_buffer(io.StringIO(docstring))
+
+
+class DocTestRunner(TestRunner):
+    def __init__(self, *, yc):
+        self._tmpdir = pathlib.Path.cwd() / ".yeadoc"
+        if self._tmpdir.exists():
+            shutil.rmtree(self._tmpdir)
+        self._tmpdir.mkdir()
+        super().__init__(yc=yc)
+
+    def _populate(self):
+        tpaths = []
+
+        args_tests = self._get_args_list() or []
+
+        all_tests = False
+        if self._args.action == "list" and not self._args.tests:
+            all_tests = True
+        if self._args.action == "run" and self._args.all:
+            all_tests = True
+
+        id_test_map: Dict[str, YeadocSnippet] = {}
+
+        for path_dir in self._get_dirs():
+            # build up the list of tests that can be run by parsing docstrings
+            for tpath in path_dir.glob("*.py"):
+
+                # parse the test file using ast
+                with open(tpath) as f:
+                    mod = ast.parse(f.read())
+
+                function_definitions = [node for node in mod.body if isinstance(node, ast.FunctionDef)]
+                for func in function_definitions:
+                    docstr = ast.get_docstring(func)
+                    snippets = load_tests_from_docstring(docstr)
+                    for s in snippets:
+                        id_test_map[s.id] = s
+
+        for path_dir in self._get_dirs():
+            for tpath in path_dir.glob("*.yea"):
+                # TODO: parse yea file looking for path info
+                spec = testspec.load_yaml_from_file(tpath)
+                id_not_in_map = spec.get("id", None) not in id_test_map
+                test_selected_to_run = all_tests or spec.get("id", None) in args_tests
+
+                if id_not_in_map or not test_selected_to_run:
+                    logger.debug("skip yea fname: {}".format(tpath))
+                    continue
+
+                if all_tests:
+                    if spec.get("tag", {}).get("skip", False):
+                        continue
+                    suite = spec.get("tag", {}).get("suite", "main")
+                    shard = spec.get("tag", {}).get("shard", "default")
+                    if self._args.suite and self._args.suite != suite:
+                        continue
+                    if self._args.shard and self._args.shard != shard:
+                        continue
+
+                # write test and spec to tempfiles
+                shutil.copy(tpath, self._tmpdir)
+                t_fname = self._tmpdir / tpath.name
+                py_fname = str(t_fname)[:-4] + ".py"
+                with open(py_fname, "w") as f:
+                    f.write(id_test_map[spec["id"]].code)
+
+                # add .yea or .py file
+                tpaths.append(pathlib.Path(t_fname))
+
+        tlist = []
+        for tname in tpaths:
+            t = ytest.YeaTest(tname=tname, yc=self._yc)
+            test_perms = t.get_permutations()
+            tlist.extend(test_perms)
+
+        tlist.sort(key=alphanum_sort)
+        self._test_list = tlist
+
+    def clean(self):
+        if self._tmpdir.exists():
+            shutil.rmtree(self._tmpdir)
+
+    def finish(self):
+        self.clean()
+        super().finish()

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,6 +1,6 @@
-
 import yea
 from yea import config
+
 
 def test_this():
     cf = config.Config()


### PR DESCRIPTION
Hackweek!

This PR allows yea to find tests in function and method docstrings. The idea is to use yea to automatically run  examples in our reference docs as tests to make sure they work and to motivate us to improve the quality of our docstring examples (make them more self contained pieces of code that users can just copy and paste). Yea docstring tests are specified as follows:

```python
def my_function():
    """
    This is my function. It does many things, including having a test in its docstring.

    <!--yeadoc-test:my-function-example-1-->
    ```python
    import wandb
    run = wandb.init()
    run.log({"a": 1})
    ```
    """
    return 0
```

The tag `<!--yeadoc-test: ...-->` indicates that the subsequent python snippet (indicated by 3backticks followed by python and then closed by another 3 backticks) is a yea test. It then searches the yea search paths for the corresponding `.yea` file (matching on id) and reads the asserts from there to run the test. If it cannot find a corresponding `.yea` file then it treats the test as incomplete and does not include it in `yea list`, `yea run`.

All docstrings in the yea search path are parsed. Corresponding .yea files are searched for in the yea search path. For the example above, I could have a .yea file as follows:

my_yea_file.yea
```
id: my-function-example-1
plugin: 
    - wandb
assert: 
    - :wandb:runs_len: 1
    - :op:contains:
        -  :wandb:runs[0][summary]
        -   a
```

Doc string tests are automatically picked up by `yea run ...` `yea list ...`

To run only docstring tests, do: `yea --docs-only run ...`