### PR TITLE
Make plugins configurable at runtime + allow non-str values in parametrize/permute

### DIFF
--- a/.yearc
+++ b/.yearc
@@ -1,0 +1,10 @@
+[yea]
+
+test_paths =
+  tests/
+
+coverage_config_template = .coveragerc
+coverage_source = src/yea
+coverage_source_env = YEACOV_SOURCE
+
+results_file = test-results/junit-yea.xml

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,11 @@ setup(
     packages=["yea"],
     install_requires=[
         "coverage",
-        "jsonschema",
         "importlib-metadata>=3.0.0",
+        "jsonschema",
         "junit-xml",
         "PyYAML",
+        "requests",
     ],
     package_dir={"": "src"},
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name="yea",
-    version="0.7.9",
+    version="0.7.10",
     description="Test harness breaking the sound barrier",
     packages=["yea"],
     install_requires=[

--- a/src/yea/_setup.py
+++ b/src/yea/_setup.py
@@ -34,7 +34,7 @@ def setup_plugins(params):
         mod_setup = getattr(mod, "setup", None)
         if not mod_setup:
             continue
-        mod_setup()
+        mod_setup(params)
 
 
 def setup():

--- a/src/yea/config.py
+++ b/src/yea/config.py
@@ -4,6 +4,7 @@ import configparser
 import os
 import re
 from pathlib import Path
+from typing import List
 
 
 class Config:
@@ -24,7 +25,7 @@ class Config:
             self._cfroot = Path(".")
             self._test_dirs = ["."]
 
-    def _find_config(self) -> Path:
+    def _find_config(self) -> bool:
         p = Path.cwd()
         # TODO: change to use parents
         while True:
@@ -42,13 +43,13 @@ class Config:
             p = n
         return False
 
-    def _load_config(self):
+    def _load_config(self) -> configparser.ConfigParser:
         p = self._cfname
         cf = configparser.ConfigParser()
         cf.read(p)
         return cf
 
-    def _parse_config(self, cf):
+    def _parse_config(self, cf: configparser.ConfigParser) -> List[str]:
         ycfg = cf.items("yea")
         ydict = dict(ycfg)
         test_paths = ydict.get("test_paths", "")

--- a/src/yea/plugins.py
+++ b/src/yea/plugins.py
@@ -24,6 +24,11 @@ class Plugins:
             plug = m.init_plugin(self._yc)
             self._plugin_list.append(plug)
 
+    def get_plugin(self, name: str):
+        for p in self._plugin_list:
+            if p._name == name:
+                return p
+
     def monitors_inform(self, tlist):
         for p in self._plugin_list:
             for t in tlist:

--- a/src/yea/runner.py
+++ b/src/yea/runner.py
@@ -63,7 +63,7 @@ class TestRunner:
         return alist
 
     def _get_dirs(self):
-        # generate to return all test dirs and rcursively found dirs
+        # generate to return all test dirs and recursively found dirs
         for tdir in self._cfg.test_dirs:
             path_dir = pathlib.Path(self._cfg.test_root, tdir)
             yield path_dir
@@ -117,7 +117,7 @@ class TestRunner:
                     # TODO: parse yea file looking for path info
                     spec = testspec.load_yaml_from_file(tpath)
 
-                    # if program is specied, keep track of yea file
+                    # if program is specified, keep track of yea file
                     py_fname = spec.get("command", {}).get("program")
                     if py_fname:
                         # hydrate to full path, take base from tpath
@@ -281,11 +281,11 @@ class TestRunner:
     def finish(self):
         self.clean()
         self._save_results()
-        exit = 0
+        exit_code = 0
         print("\nResults:")
         print("--------")
         if not self._results:
-            sys.exit(exit)
+            sys.exit(exit_code)
         tlen = max([len(tc.name) for tc in self._results])
         for tc in self._results:
             # TODO: fix hack that only looks at first message
@@ -296,8 +296,8 @@ class TestRunner:
 
             print("  {:<{}s}: {}{}".format(tc.name, tlen, emoji, r))
             if r:
-                exit = 1
-        sys.exit(exit)
+                exit_code = 1
+        sys.exit(exit_code)
 
     def get_tests(self):
         return self._test_list

--- a/src/yea/ytest.py
+++ b/src/yea/ytest.py
@@ -145,7 +145,7 @@ class YeaTest:
             env.update(edict)
         if self._permute_groups and self._permute_items:
             env["YEA_PARAM_NAMES"] = ",".join(self._permute_groups)
-            env["YEA_PARAM_VALUES"] = ",".join(self._permute_items)
+            env["YEA_PARAM_VALUES"] = ",".join(map(str, self._permute_items))
 
         plugins = self._test_cfg.get("plugin", [])
         if plugins:
@@ -239,7 +239,7 @@ class YeaTest:
         self._prep()
         if not self._args.dryrun:
             err = self._depend()
-            # TODO: record error insted of assert
+            # TODO: record error instead of assert
             assert not err, "Problem getting test dependencies"
             self._time_start = time.time()
             self._run()
@@ -269,10 +269,10 @@ class YeaTest:
             t._load()
             t._permute_groups = gnames
             t._permute_items = it
-            tpname = "{}-{}".format(tnum, "-".join(it))
+            tpname = f"{tnum}-{'-'.join(map(str, it))}"
             tid = t._test_cfg.get("id")
             if tid:
-                t._test_cfg["id"] = "{}.{}".format(tid, tpname)
+                t._test_cfg["id"] = f"{tid}.{tpname}"
             r.append(t)
         return r
 

--- a/src/yea/ytest.py
+++ b/src/yea/ytest.py
@@ -1,7 +1,7 @@
 """Yea test class."""
 
 import configparser
-from functools import reduce
+import functools
 import itertools
 import json
 import os
@@ -98,14 +98,12 @@ def get_config(config: Dict[str, Any], prefix: str) -> Dict[str, Any]:
                 destination[key] = value
         return destination
 
-    prefixed_items = {
-        k[len(prefix):]: v for (k, v) in config.items() if k.startswith(prefix)
-    }
+    prefixed_items = {k[len(prefix) :]: v for (k, v) in config.items() if k.startswith(prefix)}
     parsed_items = []
     for k, v in prefixed_items.items():
         parsed_items.append(parse(k, v))
 
-    return reduce(merge, parsed_items) if parsed_items else {}
+    return functools.reduce(merge, parsed_items) if parsed_items else {}
 
 
 class YeaTest:
@@ -231,7 +229,7 @@ class YeaTest:
                 for items in self._test_cfg.get("var", []):
                     for k, v in items.items():
                         if k.startswith(prefix):
-                            pnames.append(k[len(prefix):])
+                            pnames.append(k[len(prefix) :])
                             pvalues.append(v)
                 if pnames and pvalues:
                     env[f"YEA_PLUGIN_{penv}_NAMES"] = ",".join(pnames)

--- a/src/yea/ytest.py
+++ b/src/yea/ytest.py
@@ -207,19 +207,11 @@ class YeaTest:
             env["YEA_PARAM_NAMES"] = ",".join(self._permute_groups)
             env["YEA_PARAM_VALUES"] = ",".join(map(str, self._permute_items))
 
-        print("++++++++++++++++++")
-        print(self._yc._plugs._plugin_list[0]._name)
-        print("++++++++++++++++++")
-        input()
         plugins = self._test_cfg.get("plugin", [])
-        print(plugins)
         if self._permute_groups and self._permute_items:
             params = {k: v for (k, v) in zip(self._permute_groups, self._permute_items)}
         else:
             params = None
-        print(params)
-        print()
-        input()
         if plugins:
             for plugin_name in plugins:
                 prefix = f":{plugin_name}:"
@@ -228,12 +220,9 @@ class YeaTest:
                     # need to configure the plugin?
                     # get the plugin by its name
                     plug = self._yc._plugs.get_plugin(plugin_name)
-                    print(plug)
                     plugin_params = get_config(params, prefix)
-                    print(plugin_params)
                     if plugin_params:
                         plug.monitors_configure(plugin_params)
-                    input()
 
                 # process vars
                 penv = plugin_name.upper()
@@ -248,11 +237,6 @@ class YeaTest:
                     env[f"YEA_PLUGIN_{penv}_NAMES"] = ",".join(pnames)
                     env[f"YEA_PLUGIN_{penv}_VALUES"] = json.dumps(pvalues)
             env["YEA_PLUGINS"] = ",".join(plugins)
-        print("******************")
-        print(env)
-        print(cmd_list)
-        print("******************")
-        input()
         exit_code = run_command(cmd_list, env=env, timeout=timeout)
         self._retcode = exit_code
 

--- a/src/yea/ytest.py
+++ b/src/yea/ytest.py
@@ -9,16 +9,18 @@ import pathlib
 import subprocess
 import sys
 import time
-from typing import Any, Dict
+from typing import Any, Dict, List, Mapping
 
 import requests
 
 from yea import testcfg, testspec
 
 
-def run_command(cmd_list, timeout=None, env=None):
-    env = env or os.environ
-    timeout = timeout or 300
+def run_command(
+    cmd_list: List[str],
+    timeout: int = 300,
+    env: Mapping = os.environ,
+):
     print("INFO: RUNNING=", cmd_list)
     p = subprocess.Popen(cmd_list, env=env)
     try:
@@ -35,8 +37,8 @@ def run_command(cmd_list, timeout=None, env=None):
     return p.returncode
 
 
-def download(url, fname):
-    err = False
+def download(url: str, fname: str) -> bool:
+    err: bool = False
     print(f"INFO: grabbing {fname} from {url}")
     try:
         with requests.get(url, stream=True) as r:
@@ -61,7 +63,7 @@ def get_config(config: Dict[str, Any], prefix: str) -> Dict[str, Any]:
             ":wandb:mock_server:lol": True,
             ":wandb:mock_server:lmao": False,
             ":wandb:mock_server:resistance:object": "Borg",
-            ":wandb:mock_server:resistance:futile": True,
+            ":wandb:mock_server:resistance:is_futile": True,
             ":wandb:foo": "bar",
         }
         prefix = ":wandb:"
@@ -72,7 +74,7 @@ def get_config(config: Dict[str, Any], prefix: str) -> Dict[str, Any]:
         #         "lmao": False,
         #         "resistance": {
         #             "object": "Borg",
-        #             "futile": True,
+        #             "is_futile": True,
         #         },
         #     },
         #     "foo": "bar",

--- a/tests/config-test.yea
+++ b/tests/config-test.yea
@@ -1,0 +1,45 @@
+id: 0.0.1
+name: example test
+tag:
+  suite: nightly
+env:
+  - this: that
+command:
+  timeout: 3
+  program: proc.py  # this defaults to the basename of yea file + ".py"
+  args:
+    - param1
+    - param2
+plugin:
+  - wandb
+depend:
+  requirements:
+    - wandb
+  files:
+    - file: this.txt
+      source: https://raw.githubusercontent.com/wandb/wandb-testing/master/README.md
+var:
+  - runs_len:
+      :fn:len: :wandb:runs
+  - run0:
+      :fn:find:
+        - item
+        - :wandb:runs
+        - :item[config][id]: 0
+assert:
+  - :runs_len: 1
+  - :op:contains:
+      - :run0[telemetry][3]  # feature
+      - 8  # keras
+  - :wandb:runs_len: 1
+  - :wandb:runs[0][config]: {id: 0}
+  - :wandb:runs[0][summary]:
+      m1: 1
+      m2: 2
+  - :wandb:runs[0][exitcode]: 0
+parametrize:
+  permute:
+    - :yea:start_method:
+        - fork
+        - spawn
+        - forkserver

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,7 +1,0 @@
-import yea
-from yea import config
-
-
-def test_this():
-    cf = config.Config()
-    pass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,13 @@
+import configparser
+from yea import config
+
+
+def test_config():
+    cf = config.Config()
+    assert cf._coverage_config_template == ".coveragerc"
+    assert cf._coverage_source.endswith("src/yea")
+    assert cf._coverage_source_env == "YEACOV_SOURCE"
+    assert str(cf._cfname).endswith(".yearc")
+    assert isinstance(cf._cf, configparser.ConfigParser)
+    assert cf._test_dirs == ["tests/"]
+    assert cf._results_file == "test-results/junit-yea.xml"

--- a/tests/test_ytest.py
+++ b/tests/test_ytest.py
@@ -1,0 +1,61 @@
+import os
+
+import pytest  # type: ignore
+
+import yea.ytest
+
+
+def test_get_config():
+    config = {
+        ":rug:ties_room_together": True,
+        ":wandb:mock_server:lol": True,
+        ":wandb:mock_server:lmao": False,
+        ":wandb:mock_server:resistance:object": "Borg",
+        ":wandb:mock_server:resistance:is_futile": True,
+        ":wandb:foo": "bar",
+    }
+    prefix = ":wandb:"
+    parsed_config = yea.ytest.get_config(config, prefix)
+    assert parsed_config == {
+        "mock_server": {
+            "lol": True,
+            "lmao": False,
+            "resistance": {
+                "object": "Borg",
+                "is_futile": True,
+            },
+        },
+        "foo": "bar",
+    }
+
+
+def test_run_command(capsys):
+    command_list = ["echo", "'hello world'"]
+    status_code = yea.ytest.run_command(command_list)
+    assert status_code == 0
+    out, err = capsys.readouterr()
+    assert "INFO: RUNNING= [\'echo\', \"'hello world'\"]" in out
+    assert "INFO: exit= 0" in out
+    assert err == ""
+
+
+def test_download(tmp_path, capsys):
+    url = "https://raw.githubusercontent.com/wandb/yea/main/README.md"
+    fname = os.path.join(tmp_path, "README.md")
+    status_code = yea.ytest.download(url, fname)
+    assert status_code == 0
+    assert os.path.exists(fname)
+    out, err = capsys.readouterr()
+    assert f"INFO: grabbing {fname} from" in out
+    assert err == ""
+
+
+def test_download_error(tmp_path, capsys):
+    url = "https://raw.githubusercontent.com/wandb/yea/main/README.mr"
+    fname = os.path.join(tmp_path, "README.md")
+    status_code = yea.ytest.download(url, fname)
+    assert status_code == 1
+    assert not os.path.exists(fname)
+    out, err = capsys.readouterr()
+    assert f"ERROR: url download error" in out
+    assert err == ""


### PR DESCRIPTION
In this PR:

- Make plugins configurable at test runtime.

Purpose: I want to be able to update `mock_server`'s context just before running tests.

Example use case: `functional_tests/code-save/code-save-disabled.yea`:

```yaml
id: 0.code-save.1-disabled
plugin:
  - wandb
command:
  program: code-save.py
env:
  - WANDB_DISABLE_CODE: "true"
parametrize:
  permute:
    - :wandb:mock_server:code_saving_enabled:
      - null
assert:
  - :wandb:runs_len: 1
  - :wandb:runs[0][config]: {}
  - :wandb:runs[0][summary]: {}
  - :wandb:runs[0][exitcode]: 0
  - :op:not_contains:
    - :wandb:runs[0][config_wandb]
    - code_path
  - :op:not_contains:
    - :wandb:runs[0][files]
    - code/functional_tests/code-save/code-save.py
```

With the new Settings object, `save_code` is a policy setting meaning that the value that is set by default in `mock_server` (with `Source.USER == 5`) has priority over the env variable that this test defines (`Source.ENV == 8`). 

The proposed solution is to make `mock_server` configurable via the `parametrize.permute` route as demonstrated in the example above. The config is (recursively) "unpacked" and applied to the mock_server context just before executing the test. The implementation seems general enough to be used in other circumstances/for other plugin config purposes.

- Allow non-str values in parametrize/permute

For example,

```yaml
parametrize:
  permute:
    - :wandb:mock_server:code_saving_enabled:
      - null
      - lol
```

which results in something like `0.code-save.1-disabled.0-None` and `0.code-save.1-disabled.1-lol`.