### PR TITLE
Print timing info on executed tests

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.18-dev
+current_version = 0.7.18
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
-current_version = 0.7.17
+current_version = 0.7.18-dev
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{release}
 	{major}.{minor}.{patch}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# Install pre-commit hooks via `pip install pre-commit && pre-commit install`
+
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.2.0
+  hooks:
+  - id: check-yaml
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+- repo: https://github.com/psf/black
+  rev: 22.3.0
+  hooks:
+  - id: black
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.31.1
+  hooks:
+  - id: pyupgrade
+    args: [--py37-plus, --keep-mock]
+- repo: https://github.com/asottile/blacken-docs
+  rev: v1.12.1
+  hooks:
+  - id: blacken-docs

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="yea",
-    version="0.7.18-dev",
+    version="0.7.18",
     description="Test harness breaking the sound barrier",
     packages=["yea"],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """yea setup."""
 
 from setuptools import setup
@@ -6,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="yea",
-    version="0.7.17",
+    version="0.7.18-dev",
     description="Test harness breaking the sound barrier",
     packages=["yea"],
     install_requires=[

--- a/src/yea/__init__.py
+++ b/src/yea/__init__.py
@@ -2,4 +2,4 @@ from ._setup import setup
 
 
 __all__ = ["setup"]
-__version__ = "0.7.18-dev"
+__version__ = "0.7.18"

--- a/src/yea/__init__.py
+++ b/src/yea/__init__.py
@@ -2,4 +2,4 @@ from ._setup import setup
 
 
 __all__ = ["setup"]
-__version__ = "0.7.17"
+__version__ = "0.7.18-dev"

--- a/src/yea/cli.py
+++ b/src/yea/cli.py
@@ -78,7 +78,7 @@ def cli() -> None:
     args = parser.parse_args()
 
     if args.version:
-        print("Yea {}".format(__version__))
+        print(f"Yea {__version__}")
         sys.exit(0)
 
     if not args.action:

--- a/src/yea/context.py
+++ b/src/yea/context.py
@@ -43,7 +43,7 @@ class YeaContext:
             fmt="%(asctime)s %(levelname)-8s %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
         )
-        logfname = "debug-{}-{}.log".format(self._ts, self._pid)
+        logfname = f"debug-{self._ts}-{self._pid}.log"
         lf = self._cachedir.joinpath(logfname)
         fh = logging.FileHandler(lf)
         fh.setFormatter(formatter)

--- a/src/yea/runner.py
+++ b/src/yea/runner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """test runner."""
 import ast
 import logging
@@ -139,12 +138,12 @@ class TestRunner:
                 # TODO: look for .yea, or look for .py with docstring
                 for tpath in path_dir.glob("*.py"):
                     if not all_tests and str(tpath) not in args_tests:
-                        logger.debug("skip fname {}".format(tpath))
+                        logger.debug(f"skip fname {tpath}")
                         continue
                     docstr = testspec.load_docstring(tpath)
                     spec = testspec.load_yaml_from_docstring(docstr)
                     if not spec:
-                        logger.debug("skip nospec {}".format(tpath))
+                        logger.debug(f"skip nospec {tpath}")
                         continue
 
                     if all_tests:
@@ -153,7 +152,7 @@ class TestRunner:
 
                     if not all_tests:
                         if (str(tpath) not in args_tests) or self._should_skip_test(spec):
-                            logger.debug("skip yea fname {}".format(tpath))
+                            logger.debug(f"skip yea fname {tpath}")
                             continue
 
                     tpaths.append(tpath)
@@ -183,7 +182,7 @@ class TestRunner:
                         if (py_fname not in args_tests and str(tpath) not in args_tests) or self._should_skip_test(
                             spec
                         ):
-                            logger.debug("skip yea fname {}".format(tpath))
+                            logger.debug(f"skip yea fname {tpath}")
                             continue
 
                     # add .yea or .py file
@@ -228,7 +227,7 @@ class TestRunner:
                 test_selected_to_run = all_tests or str(tpath) in args_tests
 
                 if id_not_in_map or not test_selected_to_run:
-                    logger.debug("skip yea fname: {}".format(tpath))
+                    logger.debug(f"skip yea fname: {tpath}")
                     continue
 
                 if all_tests:
@@ -278,11 +277,11 @@ class TestRunner:
         for k, v in actual.items():
             exp = expected.get(k)
             if exp != v:
-                result.append("BAD_{}({}:{}!={})".format(s, k, exp, v))
+                result.append(f"BAD_{s}({k}:{exp}!={v})")
         for k, v in expected.items():
             act = actual.get(k)
             if v != act:
-                result.append("BAD_{}({}:{}!={})".format(s, k, v, act))
+                result.append(f"BAD_{s}({k}:{v}!={act})")
 
     def _capture_result(self, t: "ytest.YeaTest") -> None:
         test_cfg = t._test_cfg
@@ -337,7 +336,7 @@ class TestRunner:
         print("--------")
         if not self._results:
             sys.exit(exit_code)
-        tlen = max([len(tc.name) for tc in self._results])
+        tlen = max(len(tc.name) for tc in self._results)
 
         use_emoji = not sys.platform.startswith("win")
         for tc in self._results:
@@ -352,13 +351,10 @@ class TestRunner:
                 exit_code = 1
 
         # timing info
-        print("\n\nTest durations (sec):")
+        print("\nTest durations (sec):")
         print("---------------------")
         timing_info = sorted(
-            [
-                (tc.elapsed_sec, tc.name)
-                for tc in self._results
-            ],
+            ((tc.elapsed_sec, tc.name) for tc in self._results),
             reverse=True,
         )
         for tc in timing_info:

--- a/src/yea/runner.py
+++ b/src/yea/runner.py
@@ -350,6 +350,20 @@ class TestRunner:
             print("  {:<{}s}: {}{}".format(tc.name, tlen, emoji, r))
             if r:
                 exit_code = 1
+
+        # timing info
+        print("\n\nTest durations (sec):")
+        print("---------------------")
+        timing_info = sorted(
+            [
+                (tc.elapsed_sec, tc.name)
+                for tc in self._results
+            ],
+            reverse=True,
+        )
+        for tc in timing_info:
+            print(f"  {tc[1]:<{tlen}s}: {tc[0]:.1f}")
+
         sys.exit(exit_code)
 
     def get_tests(self) -> List["ytest.YeaTest"]:

--- a/src/yea/runner.py
+++ b/src/yea/runner.py
@@ -326,7 +326,7 @@ class TestRunner:
         testdir = p.parent  # get the directory portion of path
         testdir.mkdir(parents=True, exist_ok=True)
         with open(p, "w") as f:
-            junit_xml.TestSuite.to_file(f, [ts], prettyprint=False, encoding="utf-8")
+            junit_xml.to_xml_report_file(f, [ts], prettyprint=False, encoding="utf-8")
 
     def finish(self) -> None:
         self.clean()

--- a/src/yea/schema.py
+++ b/src/yea/schema.py
@@ -8,7 +8,7 @@ import jsonschema  # type:ignore
 from jsonschema import Draft7Validator, validators
 
 testlib_config_jsonschema_fname = Path(__file__).parent / "schema-yea.json"
-with open(testlib_config_jsonschema_fname, "r") as f:
+with open(testlib_config_jsonschema_fname) as f:
     testlib_config_jsonschema = json.load(f)
 
 

--- a/src/yea/testcfg.py
+++ b/src/yea/testcfg.py
@@ -20,7 +20,7 @@ def schema_violations_from_proposed_config(config: Dict) -> List[str]:
 
 class TestlibConfig(dict):
     def __init__(self, d: Dict):
-        super(TestlibConfig, self).__init__(d)
+        super().__init__(d)
 
         if not isinstance(d, TestlibConfig):
             # ensure the data conform to the schema

--- a/src/yea/ytest.py
+++ b/src/yea/ytest.py
@@ -279,7 +279,7 @@ class YeaTest:
         # dont mess with coverage_file (for now) if already set
         if self._yc._covfile is not None:
             return
-        covfname = ".coverage-{}-{}".format(self._yc._pid, self.test_id)
+        covfname = f".coverage-{self._yc._pid}-{self.test_id}"
         covfile = self._yc._cachedir.joinpath(covfname)
         os.environ["COVERAGE_FILE"] = str(covfile)
 

--- a/tests/assets/sample03.py
+++ b/tests/assets/sample03.py
@@ -2,7 +2,7 @@
 """Test a batch of import telemetry
 
 ---
-id: 0.sample.02
+id: 0.sample.03
 tag:
   skips:
     - platform: win

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 from typing import Callable, List, Optional
+from unittest import mock
 
 
 if sys.version_info >= (3, 8):
@@ -40,7 +41,7 @@ def default_cli_args(
         "shard": shard,
         "suite": suite,
         "tests": tests,
-        "plugin_args": plugin_args
+        "plugin_args": plugin_args,
     }
 
 
@@ -50,3 +51,9 @@ def mocked_yea_context(request):
     args = CliArgs(argparse.Namespace(**cli_args))
 
     yield YeaContext(args=args)
+
+
+@pytest.fixture(autouse=True)
+def sys_exit():
+    with mock.patch("sys.exit", lambda x: print(f"SystemExit: {x}")):
+        yield

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -15,7 +15,7 @@ from yea.runner import TestRunner
             "tests": [
                 "tests/assets/sample01.yea",
                 "tests/assets/sample02.yea",
-            ]
+            ],
         }
     ],
     indirect=True,
@@ -34,13 +34,12 @@ def test_runner_skip(mocked_yea_context: YeaContext):
             "action": "run",
             "tests": [
                 "tests/assets/sample03.py",
-            ]
+            ],
         }
     ],
     indirect=True,
 )
 def test_runner_skips_platform(mocked_yea_context: YeaContext):
-    print(mocked_yea_context._args.__dict__)
     with mock.patch("sys.platform", "windows 95"):
         runner = TestRunner(yc=mocked_yea_context)
         tests_to_run = {t._tname for t in runner._test_list}
@@ -50,3 +49,29 @@ def test_runner_skips_platform(mocked_yea_context: YeaContext):
         tests_to_run = {t._tname for t in runner._test_list}
         assert len(tests_to_run) == 1
         assert pathlib.Path("tests/assets/sample03.py").resolve() in tests_to_run
+
+
+@pytest.mark.parametrize(
+    "mocked_yea_context",
+    [
+        {
+            "action": "run",
+            "tests": [
+                "tests/assets/sample03.py",
+            ],
+        }
+    ],
+    indirect=True,
+)
+def test_runner_run(mocked_yea_context: YeaContext, capsys):
+    with mock.patch("sys.platform", "darwin"):
+        with mock.patch("sys.exit", lambda x: print(f"SystemExit: {x}")):
+            runner = TestRunner(yc=mocked_yea_context)
+            runner.run()
+            captured = capsys.readouterr().out
+            assert "0.sample.03" in captured
+            assert "INFO: RUNNING= ['coverage', 'run', '--rcfile'," in captured
+            assert "Results:" in captured
+            assert "😃" in captured
+            assert "Test durations (sec):" in captured
+            assert "SystemExit: 0" in captured

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 from yea.context import YeaContext
-from yea.runner import TestRunner
+from yea.runner import TestRunner as Runner  # not to confuse pytest
 
 
 @pytest.mark.parametrize(
@@ -21,7 +21,7 @@ from yea.runner import TestRunner
     indirect=True,
 )
 def test_runner_skip(mocked_yea_context: YeaContext):
-    runner = TestRunner(yc=mocked_yea_context)
+    runner = Runner(yc=mocked_yea_context)
     tests_to_run = {t._tname for t in runner._test_list}
     assert pathlib.Path("tests/assets/sample01.yea").resolve() not in tests_to_run
     assert pathlib.Path("tests/assets/sample02.yea").resolve() in tests_to_run
@@ -41,11 +41,11 @@ def test_runner_skip(mocked_yea_context: YeaContext):
 )
 def test_runner_skips_platform(mocked_yea_context: YeaContext):
     with mock.patch("sys.platform", "windows 95"):
-        runner = TestRunner(yc=mocked_yea_context)
+        runner = Runner(yc=mocked_yea_context)
         tests_to_run = {t._tname for t in runner._test_list}
         assert len(tests_to_run) == 0
     with mock.patch("sys.platform", "darwin"):
-        runner = TestRunner(yc=mocked_yea_context)
+        runner = Runner(yc=mocked_yea_context)
         tests_to_run = {t._tname for t in runner._test_list}
         assert len(tests_to_run) == 1
         assert pathlib.Path("tests/assets/sample03.py").resolve() in tests_to_run
@@ -65,13 +65,12 @@ def test_runner_skips_platform(mocked_yea_context: YeaContext):
 )
 def test_runner_run(mocked_yea_context: YeaContext, capsys):
     with mock.patch("sys.platform", "darwin"):
-        with mock.patch("sys.exit", lambda x: print(f"SystemExit: {x}")):
-            runner = TestRunner(yc=mocked_yea_context)
-            runner.run()
-            captured = capsys.readouterr().out
-            assert "0.sample.03" in captured
-            assert "INFO: RUNNING= ['coverage', 'run', '--rcfile'," in captured
-            assert "Results:" in captured
-            assert "😃" in captured
-            assert "Test durations (sec):" in captured
-            assert "SystemExit: 0" in captured
+        runner = Runner(yc=mocked_yea_context)
+        runner.run()
+        captured = capsys.readouterr().out
+        assert "0.sample.03" in captured
+        assert "INFO: RUNNING= ['coverage', 'run', '--rcfile'," in captured
+        assert "Results:" in captured
+        assert "😃" in captured
+        assert "Test durations (sec):" in captured
+        assert "SystemExit: 0" in captured

--- a/tools/bumpversion-tool.py
+++ b/tools/bumpversion-tool.py
@@ -15,7 +15,7 @@ args = parser.parse_args()
 
 
 def version_problem(current_version):
-    print("Unhandled version string: {}".format(current_version))
+    print(f"Unhandled version string: {current_version}")
     sys.exit(1)
 
 


### PR DESCRIPTION
In this PR:
- Print timing info on executed tests, sorted by execution time in reversed order (from slowest to fastest tests)
<img width="332" alt="image" src="https://user-images.githubusercontent.com/7557205/169616702-7b418c81-b4c6-4bfd-851e-18e16eb0e98b.png">
- Pre-commit hook to lint stuff
- Another +15% to codecov with a simple test!
